### PR TITLE
Sync new interface with isFree cookie management

### DIFF
--- a/new/api.php
+++ b/new/api.php
@@ -95,6 +95,7 @@ if ($action === 'add_paste') {
     'phone' => $info['phone'],
     'name' => $info['name'],
     'balance' => null,
+    'isFree' => true,
     'created_at' => date('c'),
   ];
   saveCookies($store, $list);

--- a/new/data/cookies-mtn.json
+++ b/new/data/cookies-mtn.json
@@ -8,7 +8,8 @@
         "phone": "27737943880",
         "name": "Pikoktfb",
         "balance": null,
-        "created_at": "2025-08-10T12:18:44+02:00"
+        "created_at": "2025-08-10T12:18:44+02:00",
+        "isFree": true
     },
     {
         "id": "619760fff46b",
@@ -19,6 +20,7 @@
         "phone": "27737618806",
         "name": "letsgo",
         "balance": null,
-        "created_at": "2025-08-10T14:40:53+02:00"
+        "created_at": "2025-08-10T14:40:53+02:00",
+        "isFree": true
     }
 ]

--- a/new/data/cookies-mtn2.json
+++ b/new/data/cookies-mtn2.json
@@ -8,6 +8,7 @@
         "phone": "27737943880",
         "name": "Pikoktfb",
         "balance": null,
-        "created_at": "2025-08-10T12:19:58+02:00"
+        "created_at": "2025-08-10T12:19:58+02:00",
+        "isFree": true
     }
 ]

--- a/new/data/cookies.json
+++ b/new/data/cookies.json
@@ -8,7 +8,8 @@
         "phone": "27780073561",
         "name": "shandymama",
         "balance": null,
-        "created_at": "2025-08-10T01:03:48+02:00"
+        "created_at": "2025-08-10T01:03:48+02:00",
+        "isFree": true
     },
     {
         "id": "7662d5f19422",
@@ -19,6 +20,7 @@
         "phone": "27646337204",
         "name": "BiggieSmalls",
         "balance": null,
-        "created_at": "2025-08-10T15:20:36+02:00"
+        "created_at": "2025-08-10T15:20:36+02:00",
+        "isFree": true
     }
 ]

--- a/new/requests.php
+++ b/new/requests.php
@@ -1,0 +1,73 @@
+<?php
+require_once(__DIR__ . '/../Tools-mtn-v2.php');
+$scoreTarget = TargetScore();
+system('sudo rm -rf cache');
+require_once '/var/www/html/newupdate/Zebra_cURL.php';
+$curl = new Zebra_cURL();
+$curl->cache('/var/www/html/newupdate/cache', 59);
+$curl->ssl(true, 2, '/var/www/html/newupdate/cacert.pem');
+$curl->threads = 10;
+$curl->option(CURLOPT_TIMEOUT, 2400);
+@unlink('cache');
+
+$starttime = microtime(true);
+
+$cookieFile = __DIR__ . '/data/cookies-mtn.json';
+$maxConcurrent = 2;
+$selectedIndexes = [];
+$urls_ar = [];
+while (true) {
+    $fp = fopen($cookieFile, 'c+');
+    if (flock($fp, LOCK_EX)) {
+        $cookies = json_decode(stream_get_contents($fp), true);
+        foreach ($cookies as $idx => $cookie) {
+            if (!empty($cookie['isFree'])) {
+                $cookies[$idx]['isFree'] = false;
+                $selectedIndexes[] = $idx;
+                $urls_ar[] = $cookie['cookie'];
+                if (count($urls_ar) >= $maxConcurrent) break;
+            }
+        }
+        ftruncate($fp, 0);
+        rewind($fp);
+        fwrite($fp, json_encode($cookies, JSON_PRETTY_PRINT));
+        flock($fp, LOCK_UN);
+        fclose($fp);
+        if (!empty($urls_ar)) break;
+    } else {
+        fclose($fp);
+    }
+    sleep(1);
+}
+
+$serverIP = trim(gethostbyname(gethostname()));
+echo "\nIP ADDR: $serverIP";
+$urls = [];
+foreach ($urls_ar as $c) {
+    $urls[] = 'http://' . $serverIP . '/newupdate/xavi-test.php?c=' . urlencode($c);
+}
+
+$curl->get($urls, function($result) {
+    if ($result->response[1] == CURLE_OK) {
+        echo 'Success: ', $result->body;
+    } else {
+        echo 'Error: ', $result->response[0], PHP_EOL;
+    }
+});
+
+$fp = fopen($cookieFile, 'c+');
+flock($fp, LOCK_EX);
+$cookies = json_decode(stream_get_contents($fp), true);
+foreach ($selectedIndexes as $idx) {
+    $cookies[$idx]['isFree'] = true;
+}
+ftruncate($fp, 0);
+rewind($fp);
+fwrite($fp, json_encode($cookies, JSON_PRETTY_PRINT));
+flock($fp, LOCK_UN);
+fclose($fp);
+
+$endtime = microtime(true);
+$duration = $endtime - $starttime;
+echo "Execution time: " . $duration . " seconds";
+?>

--- a/new/update-mtn.php
+++ b/new/update-mtn.php
@@ -1,0 +1,18 @@
+<?php
+$cookieFile = __DIR__ . '/data/cookies-mtn.json';
+if (!file_exists($cookieFile)) {
+    fwrite(STDERR, "Cookie file not found\n");
+    exit(1);
+}
+$data = file_get_contents($cookieFile);
+$cookies = json_decode($data, true);
+if (!is_array($cookies)) {
+    fwrite(STDERR, "Invalid cookie file\n");
+    exit(1);
+}
+foreach ($cookies as &$cookie) {
+    $cookie['isFree'] = true;
+}
+file_put_contents($cookieFile, json_encode($cookies, JSON_PRETTY_PRINT));
+echo "All cookies have been unlocked.\n";
+?>

--- a/new/update-mtn2.php
+++ b/new/update-mtn2.php
@@ -1,0 +1,18 @@
+<?php
+$cookieFile = __DIR__ . '/data/cookies-mtn2.json';
+if (!file_exists($cookieFile)) {
+    fwrite(STDERR, "Cookie file not found\n");
+    exit(1);
+}
+$data = file_get_contents($cookieFile);
+$cookies = json_decode($data, true);
+if (!is_array($cookies)) {
+    fwrite(STDERR, "Invalid cookie file\n");
+    exit(1);
+}
+foreach ($cookies as &$cookie) {
+    $cookie['isFree'] = true;
+}
+file_put_contents($cookieFile, json_encode($cookies, JSON_PRETTY_PRINT));
+echo "All cookies have been unlocked.\n";
+?>

--- a/new/update.php
+++ b/new/update.php
@@ -1,0 +1,18 @@
+<?php
+$cookieFile = __DIR__ . '/data/cookies.json';
+if (!file_exists($cookieFile)) {
+    fwrite(STDERR, "Cookie file not found\n");
+    exit(1);
+}
+$data = file_get_contents($cookieFile);
+$cookies = json_decode($data, true);
+if (!is_array($cookies)) {
+    fwrite(STDERR, "Invalid cookie file\n");
+    exit(1);
+}
+foreach ($cookies as &$cookie) {
+    $cookie['isFree'] = true;
+}
+file_put_contents($cookieFile, json_encode($cookies, JSON_PRETTY_PRINT));
+echo "All cookies have been unlocked.\n";
+?>


### PR DESCRIPTION
## Summary
- Track `isFree` status for cookies added through `new/api.php`
- Provide request runner and update scripts in `new/` for managing cookies
- Embed `isFree` flags in existing cookie data files
- Dynamically select an available top ten score using configurable range in `xavi-test.php`

## Testing
- `php -l new/api.php`
- `php -l new/requests.php`
- `php -l new/update.php`
- `php -l new/update-mtn.php`
- `php -l new/update-mtn2.php`
- `php new/update.php`
- `php new/update-mtn.php`
- `php new/update-mtn2.php`
- `php -l xavi-test.php`
- `timeout 10 php xavi-test.php` *(fails: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty)*

------
https://chatgpt.com/codex/tasks/task_e_68989f9d19f48327ae6f28cf72c17af5